### PR TITLE
remove CMAKE_CXX_STANDARD

### DIFF
--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
-set(CMAKE_CXX_STANDARD 11)
-
 if(MSVC)
   add_definitions(-D_WIN32_WINNT=0x600)
 endif()


### PR DESCRIPTION
Ambience Enhancerのprojectにgrpc.cmakeをincludeした際に、プロジェクトがC++17で書かれていたためビルドがこけるようになった。grpc.cmakeでversionを指定する必要は特になさそうなのでremove