### PR TITLE
Universal binary 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ git clone git@github.com:magnetica-studio/grpc-installer.git
 cd grpc-installer
 
 # 目的のバージョン（タグ名）を指定して install.sh スクリプトファイルを実行します。
-./install.sh v1.42.0  # Intel mac
-arch -x86_64 ./install.sh v1.42.0  # M1 mac
+./install.sh v1.48.0
 
 # 指定したバージョン名のディレクトリで macOS 用と iOS 用それぞれの GRPC がビルド／インストールされます。
 # `build-*` ディレクトリがビルドディレクトリ、 `install-*` ディレクトリがインストールディレクトリになります。
 # `build-*` ディレクトリは、ビルド／インストール完了後には使用しないので、削除しても問題ありません。
-ls -la ./v1.42.0
+
+# macOS 用には、 x86_64 と arm64 の universal binary としてライブラリがビルドされます。
+# iOS 用には、 arm64 のバイナリのみがビルドされます。
+ls -la ./v1.48.0
 ```
 
 ### インストールした GRPC の利用方法
@@ -24,7 +26,7 @@ ls -la ./v1.42.0
 GRPC を利用する C++ プロジェクトの CMakeLists.txt から、以下のように `cmake/grpc.cmake` をインクルードします。
 
 ```cmake
-set(TARGET_GRPC_VERSION "v1.42.0")
+set(TARGET_GRPC_VERSION "v1.48.0")
 include("/path/to/develop/grpc-installer/cmake/grpc.cmake")
 ```
 

--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -12,7 +12,7 @@ else()
   set(PLATFORM_NAME "macOS")
 endif()
 
-# macOS 環境では grpc を universal binary としてビルドしているため、
+# macOS 向けには grpc を universal binary としてビルドしているため、
 # CMAKE_OSX_ARCHITECTURES によらず universal binary 用の
 # インストールディレクトリを使用する。
 if(${PLATFORM_NAME} STREQUAL "macOS")

--- a/install.sh
+++ b/install.sh
@@ -75,10 +75,10 @@ function build_grpc()
 
 ##################################################################
 
-echo "Build macOS"
+echo "Build macOS (universal binaries)"
 build_grpc "macOS" "x86_64;arm64" "universal" 11.10 "-UgRPC_BUILD_CODEGEN -DgRPC_BUILD_CODEGEN=YES"
 
-echo "Build iOS arm64"
+echo "Build iOS (arm64)"
 build_grpc "iOS" "arm64" "arm64" 11.10 \
   "-DCMAKE_SYSTEM_NAME=iOS -Uprotobuf_BUILD_PROTOC_BINARIES -Dprotobuf_BUILD_PROTOC_BINARIES=ON -UgRPC_BUILD_CODEGEN -DgRPC_BUILD_CODEGEN=OFF -DCARES_INSTALL=OFF -DCMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE=YES"
 


### PR DESCRIPTION
(ref https://github.com/magnetica-studio/Duo/issues/525)

macOS 向けの GRPC を universal binary としてビルドできるようにした

これによって、 install-macOS-arm64, install-macOS-x86_64 のようにアーキテクチャごとにインストールディレクトリが分かれていたのが、  install-macOS-universal というインストールディレクトリ名になる。

## 補足

universal binary 対応のために、GRPC ビルド時に `-DOPENSSL_NO_ASM=1` を付ける必要があった。
このオプションは OpenSSL を使うところでアセンブリで書かれた最適化処理を使用するかどうかを切り替えるもの。
https://grpc.github.io/grpc/core/md_doc_ssl-performance.html

これを無効化するとデータを暗号化して通信をするときのパフォーマンスに影響がでるとのこと。
（ただし、 GRPC 本家のビルド処理でも、すべての環境でこれが有効化できている訳ではないらしい。）
https://github.com/grpc/grpc/issues/9440
https://github.com/grpc/grpc/blob/master/doc/ssl-performance.md

Duo では有線接続が前提なので、これは特に問題にならないかも？